### PR TITLE
Fixes escape character sequences that are not on the last attributes

### DIFF
--- a/src/absinthe_lexer.xrl
+++ b/src/absinthe_lexer.xrl
@@ -40,7 +40,7 @@ BlockStringValue        = """{BlockStringCharacter}*"""
 HexDigit            = [0-9A-Fa-f]
 EscapedUnicode      = u{HexDigit}{HexDigit}{HexDigit}{HexDigit}
 EscapedCharacter    = ["\\\/bfnrt]
-StringCharacter     = ([^\"{_LineTerminator}]|\\{EscapedUnicode}|\\{EscapedCharacter})
+StringCharacter     = ([^\\"{_LineTerminator}]|\\{EscapedUnicode}|\\{EscapedCharacter})
 StringValue         = "{StringCharacter}*"
 
 % Boolean Value

--- a/test/absinthe/phase/parse/block_strings_test.exs
+++ b/test/absinthe/phase/parse/block_strings_test.exs
@@ -27,6 +27,37 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     assert "slashes \\\\ \\/" == extract_body(result)
   end
 
+  test "parses attributes when there are escapes" do
+    assert {:ok, result}  = run(
+      ~s<{ post(title: "title", body: "body\\\\") { name } }>
+    )
+    assert "body\\" == extract_body(result)
+
+    assert {:ok, result}  = run(
+      ~s<{ post(title: "title\\\\", body: "body") { name } }>
+    )
+    assert "body" == extract_body(result)
+  end
+
+  test "paarse attributes where there are escapes on multiple lines" do
+    assert {:ok, result}  = run(
+      ~s<{ post(
+        title: "title",
+        body: "body\\\\"
+      ) { name } }>
+    )
+    assert "body\\" == extract_body(result)
+
+    assert {:ok, result}  = run(
+      ~s<{ post(
+        title: "title\\\\",
+        body: "body"
+      ) { name } }>
+    )
+    assert "body" == extract_body(result)
+  end
+
+
   @input [
     "",
     "    Hello,",


### PR DESCRIPTION
When running with attributes that have escape characters and attributes
on the same line the order of the attributes matters for the outcome. If
the slashes appear in the last attribute then everything parses
successfully. If the attribute appears earlier in the list then an error
is returned instead.

The error:

~~~elixir
  validation_errors: [
    %Absinthe.Phase.Error{
      extra: %{},
      locations: [%{column: 0, line: 1}],
      message: "illegal: \") { name } }",
      path: [],
      phase: Absinthe.Phase.Parse
    }
  ]
~~~

This change allows the attributes to come in any order.

Amos King @adkron <amos@binarynoggin.com>

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
